### PR TITLE
Minor refactors

### DIFF
--- a/spec/progress_bar/io_writer_spec.cr
+++ b/spec/progress_bar/io_writer_spec.cr
@@ -1,0 +1,12 @@
+require "../spec_helper"
+
+describe Progress::IOWriter do
+  it "raises when read is invoked" do
+    bar = Progress::IOBar.new(total: 1)
+    writer = Progress::IOWriter.new(bar: bar)
+
+    expect_raises(IO::Error) do
+      writer.read(Bytes.new(1))
+    end
+  end
+end

--- a/spec/progress_bar/renderer_spec.cr
+++ b/spec/progress_bar/renderer_spec.cr
@@ -1,5 +1,10 @@
 require "../spec_helper"
 
 describe Progress::Renderer do
+  it "treats zero-length bars as complete" do
+    bar = Progress::Bar.new(total: 0)
+    renderer = Progress::Renderer.new(bar: bar)
 
+    renderer.percent_complete.should eq(100.0)
+  end
 end

--- a/src/progress_bar/bar.cr
+++ b/src/progress_bar/bar.cr
@@ -8,11 +8,10 @@ module Progress
     getter current, total, theme, output_stream
 
     def initialize(@total = 100, @step = 1, @theme = Theme.new,
-                   @output_stream = STDOUT)
+                   @output_stream = STDOUT, lock : Mutex = Mutex.new)
 
       @current = 0.0_f64
-      @current_tick = 0
-      @lock = Mutex.new
+      @lock = lock
       @renderer = Renderer.new(bar: self)
     end
 
@@ -20,7 +19,7 @@ module Progress
       @lock.synchronize do
         previous_value = @current
         @current += n
-        @current = @current.clamp(0.0_f64, @total)
+        @current = @current.clamp(0.0_f64, @total.to_f)
         unless @current == previous_value || no_print
           @renderer.not_nil!.print
         end

--- a/src/progress_bar/io_bar.cr
+++ b/src/progress_bar/io_bar.cr
@@ -5,15 +5,13 @@ module Progress
   class IOBar < Bar
     ONE_SECOND = Time::Span.new(seconds: 1)
 
-    def initialize(@total = 100, @step = 1, @theme = Theme.new,
-                   @output_stream = STDOUT, @lock = Mutex.new)
-
-      @current = 0.0_f64
-      @current_tick = 0
+    def initialize(total = 100, step = 1, theme = Theme.new,
+                   output_stream = STDOUT, lock = Mutex.new)
+      @lock = lock
+      super(total, step, theme, output_stream, @lock)
       @last_tick_at = Time.monotonic
       @bytes_written = 0_u64
       @throughput_lock = Mutex.new
-      @renderer = Renderer.new(bar: self)
       @progress_writer = IOWriter.new(bar: self)
     end
 
@@ -23,7 +21,7 @@ module Progress
 
     # Returns the throughput, in bytes per second.
     # Also resets the last tick to the current time
-    def caclulate_throughput(bytesize)
+    def calculate_throughput(bytesize)
       @throughput_lock.synchronize do
         delta = Time.monotonic - @last_tick_at
         @bytes_written += bytesize
@@ -33,6 +31,10 @@ module Progress
           @bytes_written = 0
         end
       end
+    end
+
+    def caclulate_throughput(bytesize)
+      calculate_throughput(bytesize)
     end
   end
 end

--- a/src/progress_bar/io_writer.cr
+++ b/src/progress_bar/io_writer.cr
@@ -1,16 +1,15 @@
 module Progress
   class IOWriter < IO
     def initialize(@bar : IOBar)
-
     end
 
     def write(slice : Bytes) : Nil
-      @bar.caclulate_throughput(slice.bytesize)
+      @bar.calculate_throughput(slice.bytesize)
       @bar.tick(slice.bytesize)
     end
 
-    def read(slice : Bytes)
-      0
+    def read(slice : Bytes) : Int32
+      raise IO::Error.new("read not supported")
     end
   end
 end

--- a/src/progress_bar/renderer.cr
+++ b/src/progress_bar/renderer.cr
@@ -29,7 +29,10 @@ module Progress
     end
 
     def percent_complete
-      @bar.current.to_f / (@bar.total.to_f / 100.to_f)
+      total = @bar.total.to_f
+      return 100.0 if total.zero?
+
+      (@bar.current.to_f / total) * 100
     end
 
     private def render_throughput
@@ -108,7 +111,10 @@ module Progress
     end
 
     private def position
-      ((@bar.current.to_f * @theme.width.to_f) / @bar.total).to_i
+      total = @bar.total.to_f
+      return @theme.width if total.zero?
+
+      ((@bar.current.to_f * @theme.width.to_f) / total).to_i
     end
   end
 end


### PR DESCRIPTION
* injects lock through initializer, clamps using float upper bound, and keeps renderer handling explicit
* percent/position calculations now guard zero-length totals to avoid division issues
* delegates setup to super, centralizes throughput tracking via calculate_throughput (keeps caclulate_throughput alias for compatibility), and tightens progress writer access
* routes writes through the corrected throughput method and raises on unsupported reads
* added coverage for zero-length bars and IOWriter read behavior