### PR TITLE
Duplicated crystal key

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,5 @@ authors:
   - Mauricio Gomes <mauricio@edge14.com>
 
 crystal: '>= 1.0.0'
-crystal: '>= 1.18.2'
 
 license: MIT


### PR DESCRIPTION
The duplicated key breaks the shards command